### PR TITLE
Add Drive Indexer n8n workflow export

### DIFF
--- a/n8n/drive_indexer.workflow.json
+++ b/n8n/drive_indexer.workflow.json
@@ -1,0 +1,470 @@
+{
+  "name": "Drive Indexer",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -600,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "triggerTimes": {
+          "item": [
+            {
+              "hour": 2,
+              "minute": 0
+            }
+          ]
+        },
+        "options": {
+          "timezone": "={{$env.TIMEZONE}}"
+        }
+      },
+      "id": "2",
+      "name": "Cron",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1.1,
+      "position": [
+        -600,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "list",
+        "returnAll": true,
+        "filters": {
+          "parents": [
+            "={{$env.GOOGLE_DRIVE_MASTER_FOLDER_ID}}"
+          ],
+          "mimeType": [
+            "text/csv",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          ]
+        },
+        "options": {
+          "resolveData": true,
+          "resolveFilePaths": true,
+          "fields": "id,name,mimeType,parents,modifiedTime,webViewLink"
+        }
+      },
+      "id": "3",
+      "name": "List Drive Files",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 2,
+      "position": [
+        -360,
+        80
+      ],
+      "credentials": {
+        "googleOAuth2Api": {
+          "id": "1",
+          "name": "Google OAuth2 Account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "functionCode": "const data = getWorkflowStaticData('global');\ndata.startTime = Date.now();\ndata.processed = 0;\ndata.embedded = 0;\ndata.skipped = 0;\nreturn items;"
+      },
+      "id": "4",
+      "name": "Init Stats",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        -120,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "batchSize": 10
+      },
+      "id": "5",
+      "name": "Split In Batches",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 1,
+      "position": [
+        120,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "download",
+        "fileId": "={{$json.id}}",
+        "binaryProperty": "data"
+      },
+      "id": "6",
+      "name": "Download File",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 2,
+      "position": [
+        360,
+        80
+      ],
+      "credentials": {
+        "googleOAuth2Api": {
+          "id": "1",
+          "name": "Google OAuth2 Account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "read",
+        "binaryPropertyName": "data",
+        "options": {
+          "range": "A1:Z2000",
+          "firstRowAsHeader": true
+        }
+      },
+      "id": "7",
+      "name": "Read Sheet",
+      "type": "n8n-nodes-base.spreadsheetFile",
+      "typeVersion": 1.2,
+      "position": [
+        600,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "// BEGIN FUNCTION CODE\nconst file = $json;                           // from Drive List\nconst rows = items.map(i => i.json);          // from Spreadsheet File (first sheet or CSV)\nconst headers = rows.length ? Object.keys(rows[0]) : [];\nconst headerLC = headers.map(h => String(h).toLowerCase());\n\n// Detect measures/dimensions by name\nconst has = (name) => headerLC.includes(name.toLowerCase());\nconst measures = [];\nconst mCands = [\"Net Sales\",\"Net Amount\",\"Gross Sales\",\"Quantity\",\"Tips\",\"Discount Amount\",\"Tax\",\"Guests\"];\nfor (const m of mCands) {\n  if (has(m)) measures.push(m);\n}\n\n// Guess month/year from filename\nfunction guessMonthYear(name) {\n  const txt = name.toLowerCase();\n  const months = [\"january\",\"february\",\"march\",\"april\",\"may\",\"june\",\"july\",\"august\",\"september\",\"october\",\"november\",\"december\",\"jan\",\"feb\",\"mar\",\"apr\",\"may\",\"jun\",\"jul\",\"aug\",\"sep\",\"sept\",\"oct\",\"nov\",\"dec\"];\n  let month = null, year = null;\n  // try YYYY-MM or YYYY_MM\n  const m1 = txt.match(/(20\\d{2})[-_](\\d{1,2})/);\n  if (m1) { year = Number(m1[1]); month = Number(m1[2]); }\n  // try \u201cMay 2024\u201d\n  if (!year) {\n    const m2 = txt.match(/(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\\s*(20\\d{2})/);\n    if (m2) {\n      const mstr = m2[1];\n      year = Number(m2[2]);\n      month = months.findIndex(x => x.startsWith(mstr)) % 12 + 1;\n    }\n  }\n  return { month, year };\n}\n\nconst { month, year } = guessMonthYear(file.name);\n\n// Grain guess\nlet grain = 'line_item';\nif (has('date') && !has('item') && (has('category') || has('payment type'))) grain = 'daily';\n\nconst rowCount = rows.length;\n\n// Profile text (\u2264600 chars)\nconst sampleHeaders = headers.slice(0,12).join(', ');\nconst measuresTxt = measures.join(', ') || 'none detected';\nconst prof = [\n  `File: ${file.name}`,\n  `Path: ${file.path || ''}`,\n  `Month: ${month || 'unknown'} Year: ${year || 'unknown'} Grain: ${grain}`,\n  `Headers: ${sampleHeaders}`,\n  `Measures: ${measuresTxt}`,\n  `Rows(sampled): ${rowCount}`\n].join(' | ');\nconst profileText = prof.slice(0, 600);\n\nreturn [\n  {\n    json: {\n      fileId: file.id || file.fileId || file.googleFileId,\n      name: file.name,\n      path: file.path || '',\n      webViewLink: file.webViewLink,\n      modifiedTime: file.modifiedTime,\n      year, month, grain,\n      columns: headers,\n      measures,\n      rowCount,\n      profileText\n    }\n  }\n];\n// END FUNCTION CODE"
+      },
+      "id": "8",
+      "name": "CSV/XLSX Profiler",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        840,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/embeddings",
+        "responseFormat": "json",
+        "jsonParameters": true,
+        "options": {},
+        "headerParametersJson": "={{ { \"Authorization\": \"Bearer \" + $env.OPENAI_API_KEY, \"Content-Type\": \"application/json\" } }}",
+        "bodyParametersJson": "={{ { model: $env.OPENAI_EMBED_MODEL, input: $json.profileText } }}"
+      },
+      "id": "9",
+      "name": "OpenAI Embeddings",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 2,
+      "position": [
+        1080,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const metadata = $item(0).$node[\"CSV/XLSX Profiler\"].json;\nconst embedding = $json.data?.[0]?.embedding || [];\nreturn [{ json: { ...metadata, embedding } }];"
+      },
+      "id": "10",
+      "name": "Prepare Qdrant Payload",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        1320,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{$env.QDRANT_URL}}/collections/toast_sheets_v1/points?wait=true",
+        "jsonParameters": true,
+        "options": {
+          "queryable": false
+        },
+        "bodyParametersJson": "={{ { points: [ { id: $json.fileId, vector: $json.embedding, payload: { fileId: $json.fileId, name: $json.name, path: $json.path, webViewLink: $json.webViewLink, modifiedTime: $json.modifiedTime, year: $json.year, month: $json.month, grain: $json.grain, columns: $json.columns, measures: $json.measures, rowCount: $json.rowCount, profileText: $json.profileText } } ] } }}"
+      },
+      "id": "11",
+      "name": "Qdrant Upsert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 2,
+      "position": [
+        1560,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "upsert",
+        "dataToSend": "keyValue",
+        "key": "={{$json.fileId}}",
+        "value": "={{$json}}",
+        "options": {},
+        "dataStoreId": "={{$env.N8N_DATA_STORE_ID}}"
+      },
+      "id": "12",
+      "name": "Cache Manifest",
+      "type": "n8n-nodes-base.dataStore",
+      "typeVersion": 1,
+      "position": [
+        1800,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const data = getWorkflowStaticData('global');\ndata.processed = (data.processed || 0) + 1;\ndata.embedded = (data.embedded || 0) + 1;\nreturn items;"
+      },
+      "id": "13",
+      "name": "Update Stats",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        2040,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "return items;"
+      },
+      "id": "14",
+      "name": "Continue Loop",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        2280,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const data = getWorkflowStaticData('global');\nconst now = new Date();\nconst timestamp = now.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });\nconst msElapsed = data.startTime ? (Date.now() - data.startTime) : 0;\nreturn [{ json: { Timestamp_PDT: timestamp, FilesProcessed: data.processed || 0, SheetsEmbedded: data.embedded || 0, SheetsSkipped: data.skipped || 0, MsElapsed: msElapsed } }];"
+      },
+      "id": "15",
+      "name": "Finalize Stats",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        360,
+        360
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "range": "RunLog!A:E",
+        "options": {
+          "valueInputMode": "USER_ENTERED"
+        },
+        "columns": [
+          "Timestamp_PDT",
+          "FilesProcessed",
+          "SheetsEmbedded",
+          "SheetsSkipped",
+          "MsElapsed"
+        ],
+        "documentId": "={{$env.GOOGLE_SHEET_RUNLOG_ID}}"
+      },
+      "id": "16",
+      "name": "Append RunLog",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4,
+      "position": [
+        600,
+        360
+      ],
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "1",
+          "name": "Google OAuth2 Sheets"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "List Drive Files",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Cron": {
+      "main": [
+        [
+          {
+            "node": "List Drive Files",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "List Drive Files": {
+      "main": [
+        [
+          {
+            "node": "Init Stats",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Init Stats": {
+      "main": [
+        [
+          {
+            "node": "Split In Batches",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split In Batches": {
+      "main": [
+        [
+          {
+            "node": "Download File",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "other": [
+        [
+          {
+            "node": "Finalize Stats",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download File": {
+      "main": [
+        [
+          {
+            "node": "Read Sheet",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Sheet": {
+      "main": [
+        [
+          {
+            "node": "CSV/XLSX Profiler",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "CSV/XLSX Profiler": {
+      "main": [
+        [
+          {
+            "node": "OpenAI Embeddings",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Embeddings": {
+      "main": [
+        [
+          {
+            "node": "Prepare Qdrant Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Qdrant Payload": {
+      "main": [
+        [
+          {
+            "node": "Qdrant Upsert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Qdrant Upsert": {
+      "main": [
+        [
+          {
+            "node": "Cache Manifest",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Cache Manifest": {
+      "main": [
+        [
+          {
+            "node": "Update Stats",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Stats": {
+      "main": [
+        [
+          {
+            "node": "Continue Loop",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Continue Loop": {
+      "main": [
+        [
+          {
+            "node": "Split In Batches",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Finalize Stats": {
+      "main": [
+        [
+          {
+            "node": "Append RunLog",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {},
+  "pinData": {},
+  "versionId": "drive_indexer_v1"
+}


### PR DESCRIPTION
## Summary
- add Drive Indexer workflow that indexes Drive spreadsheets, builds OpenAI embeddings, and upserts them into Qdrant
- cache sheet manifests in the n8n data store and append run metrics to the RunLog sheet

## Testing
- not run (workflow definition only)

------
https://chatgpt.com/codex/tasks/task_e_68e2bf5dc6048332b0c3fda1615983ca